### PR TITLE
Change ballot viewport location

### DIFF
--- a/external/openglcts/modules/gl/gl4cShaderBallotTests.cpp
+++ b/external/openglcts/modules/gl/gl4cShaderBallotTests.cpp
@@ -731,7 +731,7 @@ tcu::TestNode::IterateResult ShaderBallotFunctionReadTestCase::iterate()
 	const tcu::RenderTarget renderTarget = m_context.getRenderContext().getRenderTarget();
 
 	gl.clearColor(1.0f, 0.0f, 0.0f, 1.0f);
-	gl.viewport(renderTarget.getWidth() / 2 - 1, renderTarget.getHeight() / 2 - 1, 2, 2);
+	gl.viewport(renderTarget.getWidth() / 2, renderTarget.getHeight() / 2, 2, 2);
 
 	for (ShaderPipelineIter pipelineIter = m_shaderPipelines.begin(); pipelineIter != m_shaderPipelines.end();
 		 ++pipelineIter)


### PR DESCRIPTION
[Why]
Currently ShaderBallotFunctionRead test fails to get same color
value for 4 target pixels for which shader program derives color value
based on first active invocation index in the sub-group.
But, test doesn't make sure the quad pixels are drawn in a group,
current quad location used by test seems to be causing quad pixels
to be drawn in different groups, and results in different color values.
[How]
Set viewport to (w/2, h/2) instead of (w/2-1, h/2-1)
to get a quad location with which quad pixels will be drawn
in same sub-group.

Fix issue: #251